### PR TITLE
Fix multiple documentation typos and errors.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,15 +17,13 @@ API-Check - The DevSecOps toolset for REST APIs
 Why API-Check
 -------------
 
-API-Check focus not only in the security testing and hacking uses cases. The goal of the project is to be a complete toolset for ``DevSecOPs`` cycles and for different users profiles:
+API-Check focuses not only in the security testing and hacking use cases. The goal of the project is to become a complete toolset for ``DevSecOps`` cycles.
 
-The tool is aimed for different users profiles:
+The tools are aimed to diverse users profiles:
 
 - Developers
 - Systems SysAdmins
 - Security & pentesters
-
-Contributions are welcome, see CONTRIBUTING.md or skim existing tickets to see where you could help out.
 
 Documentation
 -------------
@@ -35,7 +33,7 @@ You can find the complete documentation at: `Documentation <https://apicheck.rea
 Authors
 -------
 
-APICheck was made by Security BBVA-Labs Team members:
+API-Check was made by BBVA-Labs Security team members:
 
 - `Cesar Gallego <https://github.com/CesarGallego>`_
 - `Daniel García (cr0hn) <https://github.com/cr0hn>`_
@@ -43,7 +41,7 @@ APICheck was made by Security BBVA-Labs Team members:
 License
 -------
 
-API-Check is Open Source and available under the `Apache 2 license <https://github.com/BBVA/apicheck/blob/master/LICENSE>`_.
+API-Check is Open Source Software and available under the `Apache 2 license <https://github.com/BBVA/apicheck/blob/master/LICENSE>`_.
 
 Contributions
 -------------

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ***********************************************
-API-Check - The DevSecOps toolset for REST APIs
+APICheck - The DevSecOps toolset for REST APIs
 ***********************************************
 
 .. image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
@@ -12,12 +12,12 @@ API-Check - The DevSecOps toolset for REST APIs
 .. figure:: https://raw.githubusercontent.com/BBVA/apicheck/master/docs/source/_static/images/apicheck-logo-150x150.png
    :align: center
 
-``API-Check`` is a complete toolset designed and created for testing REST APIs.
+``APICheck`` is a complete toolset designed and created for testing REST APIs.
 
-Why API-Check
+Why APICheck
 -------------
 
-API-Check focuses not only in the security testing and hacking use cases. The goal of the project is to become a complete toolset for ``DevSecOps`` cycles.
+APICheck focuses not only in the security testing and hacking use cases. The goal of the project is to become a complete toolset for ``DevSecOps`` cycles.
 
 The tools are aimed to diverse users profiles:
 
@@ -33,7 +33,7 @@ You can find the complete documentation at: `Documentation <https://apicheck.rea
 Authors
 -------
 
-API-Check was made by BBVA-Labs Security team members:
+APICheck was made by BBVA-Labs Security team members:
 
 - `Cesar Gallego <https://github.com/CesarGallego>`_
 - `Daniel García (cr0hn) <https://github.com/cr0hn>`_
@@ -41,7 +41,7 @@ API-Check was made by BBVA-Labs Security team members:
 License
 -------
 
-API-Check is Open Source Software and available under the `Apache 2 license <https://github.com/BBVA/apicheck/blob/master/LICENSE>`_.
+APICheck is Open Source Software and available under the `Apache 2 license <https://github.com/BBVA/apicheck/blob/master/LICENSE>`_.
 
 Contributions
 -------------

--- a/apicheck/apicheck/tools/manage/cli.py
+++ b/apicheck/apicheck/tools/manage/cli.py
@@ -28,7 +28,7 @@ ACTION_MAP = {
 
 def cli():
     parser = argparse.ArgumentParser(
-        description="API-Check manage commands"
+        description="APICheck manage commands"
     )
 
     # Add global options

--- a/apicheck/apicheck/tools/proxy/TODO.md
+++ b/apicheck/apicheck/tools/proxy/TODO.md
@@ -1,4 +1,4 @@
 [X] Filter storing assets content
 [X] Filter storing only responses for a specific host
 [ ] Try to detect REST APIs, instead of stores all req/resp. An idea is to detect content type as application/json
-[ ] Improve the building of name / version for an API when API-Check runs as proxy mode
+[ ] Improve the building of name / version for an API when APICheck runs as proxy mode

--- a/apicheck/entrypoint.sh
+++ b/apicheck/entrypoint.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 echo "**************************"
-echo " Welcome to API-Check Cli"
+echo " Welcome to APICheck Cli"
 echo "**************************"
 echo ""
-echo "You can find complete index reference at API-Check Documentation Home:"
+echo "You can find complete index reference at APICheck Documentation Home:"
 echo ""
 echo "https://apicheck.readthedocs.io/"
 echo ""

--- a/docs/source/command_reference_index.rst
+++ b/docs/source/command_reference_index.rst
@@ -1,9 +1,9 @@
 Tools & commands index
 ======================
 
-This document contains a index reference for ``API-Check`` supported commands.
+This document contains a index reference for ``APICheck`` supported commands.
 
-Command are grouped in two types ``API-Check``:
+Command are grouped in two types ``APICheck``:
 
 - :ref:`Tools <tools_reference>`
 - :ref:`Commands <commands_reference>`

--- a/docs/source/command_reference_index.rst
+++ b/docs/source/command_reference_index.rst
@@ -3,7 +3,7 @@ Tools & commands index
 
 This document contains a index reference for ``API-Check`` supported commands.
 
-Command are grouped in the two types supported by ``API-Check``:
+Command are grouped in two types ``API-Check``:
 
 - :ref:`Tools <tools_reference>`
 - :ref:`Commands <commands_reference>`
@@ -14,26 +14,26 @@ Tools
 Dataset
 +++++++
 
-- Description: Builds a dataset, analise it and create behavior graphs from user navigations stored in database.
+- Description: Builds a dataset, analyzes it and creates behavior graphs based on the user navigations stored in the database.
 - Command documentation: :ref:`Dataset tool <dataset>`
 
 Proxy
 +++++
 
-- Description: Launches a local proxy and tracks navigation through it into a database.
+- Description: Launches a local proxy and stores all the intercepted navigation traffic into the database.
 - Command documentation: :ref:`Proxy tool <proxy>`
 
 Send-To
 +++++++
 
-- Description: Send API Request to given host. Optionally can send the requests through a proxy.
+- Description: Send the given HTTP API traffic. Optionally you can specify a proxy to pass through.
 - Command documentation: :ref:`Send-to tool <send_to>`
 
 
 Commands
 ========
 
-Commands are small specific purpose commands. They follow the \*NIX philosophy.
+Commands are small components with a small & fix purpose. They follow the \*NIX philosophy.
 
 ac-j2y
 ++++++

--- a/docs/source/commands/commands.rst
+++ b/docs/source/commands/commands.rst
@@ -1,10 +1,9 @@
-
 ac-y2j
 ======
 
 .. _ac_y2j:
 
-This command convert a content from YAML format to JSON with indent option.
+This command converts a from YAML format to JSON optionally indenting the output.
 
 Usage examples:
 
@@ -28,7 +27,7 @@ ac-j2y
 
 .. _ac_j2y:
 
-This command convert a content from JSON format to YAML.
+This command convert from JSON format to YAML.
 
 Usage examples:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,7 @@ release = '1.0'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+        "sphinx.ext.todo"
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/development/creating_commands.rst
+++ b/docs/source/development/creating_commands.rst
@@ -1,19 +1,19 @@
 Creating a new commands
 =======================
 
-Before start writing new command check the :ref:`Command & tools <commands_reference>` to be sure to understand the :samp:`command` concept.
+Before start writing new commands check the :ref:`Command & tools <commands_reference>` to be sure you understand the :samp:`command` concept properly.
 
-What's a command?
------------------
+What is a command?
+------------------
 
-Command is a small utility integrated into ``API-Check`` suite. Usually is a **simple .py script**.
+A :samp:`command` is a small utility integrated into the ``API-Check`` suite. Usually is a **simple .py script**.
 
 Entry point
 +++++++++++
 
-To create a new command only you need to do is create a new :samp:`.py` file with the function :samp:`main()` inside. This function doesn't will receive any parameter.
+To create a new command the only thing you need to do is create a new :samp:`.py` file with the function :samp:`main()` inside. This function doesn't receive any parameters.
 
-This function will be used as entry point for ``API-Check``
+This function will be used as entry point for ``API-Check``.
 
 .. code-block:: python
    :linenos:
@@ -35,14 +35,14 @@ This function will be used as entry point for ``API-Check``
         main()
 
 
-**Passing information**
+**Passing information along**
 
-All of :samp:`commands` and :samp:`tools` in ``API-Check`` must receive configuration by to ways:
+All :samp:`commands` and :samp:`tools` in ``API-Check`` can receive configuration by to ways:
 
-- By cli parameter.
+- By command line parameters.
 - By standard input (:samp:`stdin`).
 
-This means that you command must be able to be executed in a pipeline.
+This means that your command must be able to be executed as part of a *pipeline*.
 
 .. code-block:: python
    :linenos:
@@ -68,11 +68,11 @@ This means that you command must be able to be executed in a pipeline.
     if __name__ == '__main__':
         main()
 
-**Information format**
+**Data format**
 
-As documented in section :ref:`Data format <data_format>` ``API-Check`` works internally with :samp:`JSON`. So the format received will be so.
+As documented in the section :ref:`Data format <data_format>`, ``API-Check`` works internally with :samp:`JSON`. So the format received will be so.
 
-Following previous example, we add parsing JSON format:
+Following the previous example, we add parsing JSON format:
 
 .. code-block:: python
    :linenos:
@@ -109,5 +109,5 @@ Following previous example, we add parsing JSON format:
 Output information
 ++++++++++++++++++
 
-To be able to chain your command into a a compatible ``API-Check`` pipeline, you command must output the execution result in the standard output (:samp:`stdout`).
+To be able to chain your command into a compatible ``API-Check`` pipeline, your command must output the execution result to the standard output (:samp:`stdout`).
 

--- a/docs/source/development/creating_commands.rst
+++ b/docs/source/development/creating_commands.rst
@@ -6,14 +6,14 @@ Before start writing new commands check the :ref:`Command & tools <commands_refe
 What is a command?
 ------------------
 
-A :samp:`command` is a small utility integrated into the ``API-Check`` suite. Usually is a **simple .py script**.
+A :samp:`command` is a small utility integrated into the ``APICheck`` suite. Usually is a **simple .py script**.
 
 Entry point
 +++++++++++
 
 To create a new command the only thing you need to do is create a new :samp:`.py` file with the function :samp:`main()` inside. This function doesn't receive any parameters.
 
-This function will be used as entry point for ``API-Check``.
+This function will be used as entry point for ``APICheck``.
 
 .. code-block:: python
    :linenos:
@@ -37,7 +37,7 @@ This function will be used as entry point for ``API-Check``.
 
 **Passing information along**
 
-All :samp:`commands` and :samp:`tools` in ``API-Check`` can receive configuration by to ways:
+All :samp:`commands` and :samp:`tools` in ``APICheck`` can receive configuration by to ways:
 
 - By command line parameters.
 - By standard input (:samp:`stdin`).
@@ -70,7 +70,7 @@ This means that your command must be able to be executed as part of a *pipeline*
 
 **Data format**
 
-As documented in the section :ref:`Data format <data_format>`, ``API-Check`` works internally with :samp:`JSON`. So the format received will be so.
+As documented in the section :ref:`Data format <data_format>`, ``APICheck`` works internally with :samp:`JSON`. So the format received will be so.
 
 Following the previous example, we add parsing JSON format:
 
@@ -109,5 +109,4 @@ Following the previous example, we add parsing JSON format:
 Output information
 ++++++++++++++++++
 
-To be able to chain your command into a compatible ``API-Check`` pipeline, your command must output the execution result to the standard output (:samp:`stdout`).
-
+To be able to chain your command into a compatible ``APICheck`` pipeline, your command must output the execution result to the standard output (:samp:`stdout`).

--- a/docs/source/development/creating_tools.rst
+++ b/docs/source/development/creating_tools.rst
@@ -1,12 +1,12 @@
 Creating a new tools
 ====================
 
-Before start writing new tool check the :ref:`Command & tools <commands_reference>` to be sure to understand the :samp:`tool` concept.
+Before start writing new commands check the :ref:`Command & tools <commands_reference>` to be sure you understand the :samp:`command` concept properly.
 
-What's a tool?
---------------
+What is a tool?
+---------------
 
-Tool is an utility integrated into ``API-Check`` suite. It does some complex thing.
+A tool is an utility integrated into the ``API-Check`` suite. Tools are not as simple as commands.
 
 Scaffolding
 -----------
@@ -14,20 +14,20 @@ Scaffolding
 Usually, a tool have these three files:
 
 - Command Line Interface contents: :samp:`cli.py`.
-- Tool configuration structures :samp:`config.py`.
-- Actions definitions file :samp:`run.py`.
+- Tool configuration structures: :samp:`config.py`.
+- Actions definitions file: :samp:`run.py`.
 
 .. note::
 
-   These 3 files are not mandatory. The only required file is the :samp:`cli.py`
+   The only mandatory file is :samp:`cli.py`; the others can be left out.
 
 Building New tool
 -----------------
 
-``API-Check`` has an integrated manage tool to help us to develop new tools. To create new tool you can run :samp:`create-tool` action.
+``API-Check`` has an integrated management tool to help us in the development of new tools. To create a new tool you can run :samp:`create-tool` action.
 
 .. code-block:: console
 
    > at-manage create-tool my_new_tool
 
-This command will create a new scaffolding. Each file is self-documented.
+This command will create the needed scaffolding. Each file is self-documented.

--- a/docs/source/development/creating_tools.rst
+++ b/docs/source/development/creating_tools.rst
@@ -6,7 +6,7 @@ Before start writing new commands check the :ref:`Command & tools <commands_refe
 What is a tool?
 ---------------
 
-A tool is an utility integrated into the ``API-Check`` suite. Tools are not as simple as commands.
+A tool is an utility integrated into the ``APICheck`` suite. Tools are not as simple as commands.
 
 Scaffolding
 -----------
@@ -24,7 +24,7 @@ Usually, a tool have these three files:
 Building New tool
 -----------------
 
-``API-Check`` has an integrated management tool to help us in the development of new tools. To create a new tool you can run :samp:`create-tool` action.
+``APICheck`` has an integrated management tool to help us in the development of new tools. To create a new tool you can run :samp:`create-tool` action.
 
 .. code-block:: console
 

--- a/docs/source/home/installation_and_quickstart.rst
+++ b/docs/source/home/installation_and_quickstart.rst
@@ -1,7 +1,7 @@
 Installation & Quick start
 ==========================
 
-``API-Check`` uses `MITM Proxy <https://mitmproxy.org>`_ then you must install all the dependencies inherited from them. It's easy to install them. You can `follow their documentation <https://docs.mitmproxy.org/stable/overview-installation/>`_.
+``API-Check`` levarages `MITM Proxy <https://mitmproxy.org>`_ so you must install all its dependencies (don't worry, it's easy, just `follow their documentation <https://docs.mitmproxy.org/stable/overview-installation/>`_).
 
 .. _installation:
 
@@ -18,7 +18,7 @@ Using Pip
 
 .. note::
 
-    **MySQL Support**: If you want to install ``API-Check`` with Mysql Support you must install as follows:
+    **MySQL Support**: If you want to install ``API-Check`` with Mysql Support use this command instead:
 
     .. code-block:: console
 
@@ -34,7 +34,7 @@ Using Docker
 Using interactive CLI
 +++++++++++++++++++++
 
-If you want to open an interactive CLI for testing an API you can run:
+Use this command to open an interactive CLI for API testing:
 
 .. code-block:: console
 
@@ -43,21 +43,21 @@ If you want to open an interactive CLI for testing an API you can run:
 Quick Start
 -----------
 
-Use ``API-Check`` is very easy. After :ref:`install <installation>` you can type cli commands.
+The usage of ``API-Check`` is quite simple. After :ref:`install <installation>` you'll have all **tools** and **commands** available as shell commands.
 
-``API-Check`` has a lot of commands. You can find the complete reference in :doc:`/command_reference_index` and you also can check grouped commands by the purpose of you want to use ``API-Check`` in the :doc:`/uses_cases/uses_cases_overview`.
+``API-Check`` has a lot of commands. You can find the complete reference in :doc:`/command_reference_index` and a list of curated recipes grouped by use case in :doc:`/uses_cases/uses_cases_overview`.
 
-Learning by examples: Discovering non-documented APIs
------------------------------------------------------
+Learning by example: Discovering non-documented APIs
+----------------------------------------------------
 
-One of the more complex things you can find when try to test an API is the missing documentation. Most of the REST API have not the *auto-discover* option. For this reason ``API-Check`` has the **proxy** working mode.
+One of the biggest problems you'll face while testing an API is the lack of documentation. The majority of REST API are not designed to be *auto-discoverable*. For this reason ``API-Check`` has the **proxy** command.
 
 1 - Launching the proxy
 +++++++++++++++++++++++
 
-**Proxy** working mode launches an local proxy that track all request for a specific domain. ``API-Check`` stores this request in a database. With this information, ``API-Check`` can perform a lot of operations with the API, one of them: derive the API definition and test it.
+``API-Check``'s **proxy** command is a local proxy that track all request for a specific domain. ``API-Check`` stores this requests into a database. With this data, ``API-Check`` can perform tons of operations with the API, one of them: derive the API definition and test it.
 
-To start the proxy mode we must execute the following command:
+To start the proxy we execute:
 
 .. code-block:: console
 
@@ -66,22 +66,22 @@ To start the proxy mode we must execute the following command:
 2 - Configuring proxy and browsing
 +++++++++++++++++++++++++++++++++++
 
-Once we have been launched the proxy, we must `configure it into the browser <https://www2.aston.ac.uk/library/staff/mozillaproxy/index>`_.
+Once we have the proxy running, we must `configure the browser to use it<https://www2.aston.ac.uk/library/staff/mozillaproxy/index>`_.
 
-In this step we must browsing in the web site we want to extract the REST API.
+At this stage we must browse the website we want to extract the REST API from.
 
 .. note::
 
-    Currently ``API-Check`` only can take actions with these APIs that was pass throught the proxy. Then we must be thorough in the browsing in the web site.
+    Currently ``API-Check`` only can take actions with these APIs that was pass throught the proxy. Therefore we must be thorough browsing the website.
 
-3 - Perform actions recovered information
-+++++++++++++++++++++++++++++++++++++++++
+3 - Perform actions with the recovered information
+++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Once we have the API browsing information, we can perform actions to them:
+Once we have the API browsing information, we can perform actions:
 
 **Send information to hacking tool**
 
-The most simple action is to replay API endpoint to hacking tools that works as a proxies. This means: `OWASP ZAP <https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project>`_, `Burp Suite <https://portswigger.net/burp>`_ or whatever you want.
+The most simple action is to replay the browsing history to other hacking tools that work as proxies. For instance: `OWASP ZAP <https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project>`_, `Burp Suite <https://portswigger.net/burp>`_ or whatever you want.
 
 .. code-block::
 
@@ -91,7 +91,7 @@ The most simple action is to replay API endpoint to hacking tools that works as 
 Listing actions
 ---------------
 
-For helping the usage, you can list all ``API-Check`` actions using the command ``ap-help``. This command will display the complete list of commands.
+To assist in the usage, you can list all ``API-Check`` commands using the ``ap-help`` command. This command will display a complete list of commands.
 
 .. code-block:: console
 

--- a/docs/source/home/installation_and_quickstart.rst
+++ b/docs/source/home/installation_and_quickstart.rst
@@ -1,7 +1,7 @@
 Installation & Quick start
 ==========================
 
-``API-Check`` levarages `MITM Proxy <https://mitmproxy.org>`_ so you must install all its dependencies (don't worry, it's easy, just `follow their documentation <https://docs.mitmproxy.org/stable/overview-installation/>`_).
+``APICheck`` levarages `MITM Proxy <https://mitmproxy.org>`_ so you must install all its dependencies (don't worry, it's easy, just `follow their documentation <https://docs.mitmproxy.org/stable/overview-installation/>`_).
 
 .. _installation:
 
@@ -18,7 +18,7 @@ Using Pip
 
 .. note::
 
-    **MySQL Support**: If you want to install ``API-Check`` with Mysql Support use this command instead:
+    **MySQL Support**: If you want to install ``APICheck`` with Mysql Support use this command instead:
 
     .. code-block:: console
 
@@ -43,19 +43,19 @@ Use this command to open an interactive CLI for API testing:
 Quick Start
 -----------
 
-The usage of ``API-Check`` is quite simple. After :ref:`install <installation>` you'll have all **tools** and **commands** available as shell commands.
+The usage of ``APICheck`` is quite simple. After :ref:`install <installation>` you'll have all **tools** and **commands** available as shell commands.
 
-``API-Check`` has a lot of commands. You can find the complete reference in :doc:`/command_reference_index` and a list of curated recipes grouped by use case in :doc:`/uses_cases/uses_cases_overview`.
+``APICheck`` has a lot of commands. You can find the complete reference in :doc:`/command_reference_index` and a list of curated recipes grouped by use case in :doc:`/uses_cases/uses_cases_overview`.
 
 Learning by example: Discovering non-documented APIs
 ----------------------------------------------------
 
-One of the biggest problems you'll face while testing an API is the lack of documentation. The majority of REST API are not designed to be *auto-discoverable*. For this reason ``API-Check`` has the **proxy** command.
+One of the biggest problems you'll face while testing an API is the lack of documentation. The majority of REST API are not designed to be *auto-discoverable*. For this reason ``APICheck`` has the **proxy** command.
 
 1 - Launching the proxy
 +++++++++++++++++++++++
 
-``API-Check``'s **proxy** command is a local proxy that track all request for a specific domain. ``API-Check`` stores this requests into a database. With this data, ``API-Check`` can perform tons of operations with the API, one of them: derive the API definition and test it.
+``APICheck``'s **proxy** command is a local proxy that track all request for a specific domain. ``APICheck`` stores this requests into a database. With this data, ``APICheck`` can perform tons of operations with the API, one of them: derive the API definition and test it.
 
 To start the proxy we execute:
 
@@ -72,7 +72,7 @@ At this stage we must browse the website we want to extract the REST API from.
 
 .. note::
 
-    Currently ``API-Check`` only can take actions with these APIs that was pass throught the proxy. Therefore we must be thorough browsing the website.
+    Currently ``APICheck`` only can take actions with these APIs that was pass throught the proxy. Therefore we must be thorough browsing the website.
 
 3 - Perform actions with the recovered information
 ++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -91,7 +91,7 @@ The most simple action is to replay the browsing history to other hacking tools 
 Listing actions
 ---------------
 
-To assist in the usage, you can list all ``API-Check`` commands using the ``ap-help`` command. This command will display a complete list of commands.
+To assist in the usage, you can list all ``APICheck`` commands using the ``ap-help`` command. This command will display a complete list of commands.
 
 .. code-block:: console
 

--- a/docs/source/home/internals.rst
+++ b/docs/source/home/internals.rst
@@ -7,12 +7,13 @@ Pipelines & data flow
 Pipelines
 +++++++++
 
-As \*NIX like you can chain :samp:`commands` and :samp:`tools`. Imagine this \*NIX *pipeline* execution:
+In \*NIX you can chain multiple commands together in a *pipeline*. Consider this one:
 
 .. image:: /_static/images/apicheck_unix_pipeline.png
    :align: center
 
-You can build the ``API-Check``-like *pipeline* doing:
+
+In a similar fashion you can build ``API-Check`` *pipelines* chaining :samp:`commands` and :samp:`tools`. For example:
 
 .. image:: /_static/images/apicheck_unix_pipeline.png
    :align: center
@@ -22,7 +23,7 @@ You can build the ``API-Check``-like *pipeline* doing:
 Data format
 +++++++++++
 
-:samp:`commands` and :samp:`tools` receives from input and output information that allow to build pipelines (as we learnt in the previous section). To do that, they may share *speak* the same data format. The chosen data format for ``API-Check`` is :samp:`JSON`.
+To allow interoperation among :samp:`commands` and :samp:`tools` all of them share a common :samp:`JSON` data format. In other words, all of ``API-Check`` command output is :samp:`JSON` as well as the input. This allows to build pipelines (as we learnt in the previous section).
 
 Commands and Tools
 
@@ -34,7 +35,7 @@ Commands and Tools
 Commands & tools
 ----------------
 
-``API-Check`` has 2:
+We divide ``API-Check`` components into two categories:
 
 - Commands
 - Tools
@@ -44,38 +45,34 @@ Commands & tools
 Commands
 ++++++++
 
-Commands are a small programs that have more specific things. These commands follow the \*NIX philosophy: a lot os small pieces, but that can be connected between them.
+Commands are programs with well-defined small jobs. Commands follow the \*NIX philosophy: multiple small elements that can be connected together.
 
-You can imagine this commands as a ``awk`` or ``grep`` commands. Small, but powerful.
+You can compare those commands to ``awk`` or ``grep``. Small, but powerful.
 
 .. _tools_reference:
 
 Tools
 +++++
 
-Tools does more complex things that a command. You also can chain with commands.
+Tools are more convoluted than commands. The problem they solve is more complex. You also can chain them along with commands.
 
 .. _data_generation:
 
 Data generation
 ---------------
 
-All data generation tools are placed into apicheck.core.generator. Inside this
-package you can find apicheck.core.generator.open_api_strategy with the default
-strategy for open api files.
+Data generation tools are placed inside the `apicheck.core.generator` package. For instance `apicheck.core.generator.open_api_strategy` that implements the default data generation strategy for OpenAPI files.
 
 .. note::
-    By the moment string format it's not supported.
+    At the moment string formating is not supported.
 
-The generator will use the Faker package to generate data, following the
-openapi specification.
+The generator uses a Python package named ``Faker`` to generate fake data following the OpenAPI specification.
 
 Request definition
 ++++++++++++++++++
 
-The overall definition used across the file is the request definition. A request
-definition describe, in a very simple terms, how the request will look like.
-This definition allways have the same fields:
+A request definition describe, in a very simple terms, how the request will look like.
+This definition always have the same fields:
 
 .. code-block:: yaml
 
@@ -100,10 +97,10 @@ The fixed value looks like the following:
 Type definition
 +++++++++++++++
 
-The type used in apicheck is a direct copy of the type definition of open api 3
+The type used in ``API-Check`` is a direct copy of the type definition of OpenAPI 3
 specification.
-Every item can be defined as an open api type. You can use also some custom
-type created for apicheck. One of this is dictionary, that looks like:
+Every item can be defined as an OpenAPI type. You can use custom
+types created for ``API-Check`` also. One of the allowed types is *dictionary*, that looks like:
 
 .. code-block:: yaml
 
@@ -113,7 +110,7 @@ type created for apicheck. One of this is dictionary, that looks like:
         - B
         - C
 
-Used to define the userName field will look like:
+The definition of the *userName* field would look like:
 
 .. code-block:: yaml
 
@@ -127,8 +124,8 @@ Used to define the userName field will look like:
 Definition hierarchy
 ++++++++++++++++++++
 
-If software find several definition for the same element the last readed will
-remain. The following is the typical order or reading:
+If several definition for the same element are found, the last read will
+remain. The default precedence order when reading is the following:
 
     - Open Api 3 File
     - Rules files (readed in search order)
@@ -139,15 +136,12 @@ remain. The following is the typical order or reading:
 Definition override
 +++++++++++++++++++
 
-If we want to start from scratch a type definition, we must use de override
-keyword. By default this keyword has the false value. If we find the true
-value then the generator will use only our specification and will ignore
-the Open Api specification.
+When starting a type definition from scratch, we must use de *override* keyword. The value of this keyword is *false* by default. When the value *true* is provided, the generator will use only our specification and ignore the OpenAPI specification.
 
-OpenApi 3 override Example
+OpenAPI 3 override Example
 ++++++++++++++++++++++++++
 
-You can override openapi 3 type definition using your own file, like this:
+You can override OpenAPI 3 type definitions using your own file this way:
 
 .. code-block:: yaml
 
@@ -184,8 +178,8 @@ You can override openapi 3 type definition using your own file, like this:
             get:
                 override: true
 
-The first part is about metadata. You can query apicheck to find a set of
-rules using this data. Name and version are required, all other data is
+The first part is metadata. You can query ApiCheck to get the set of
+rules using this data. Name and version are required, any other datum is
 optional.
 
 .. code-block:: yaml
@@ -197,7 +191,7 @@ optional.
         - books
         - users
 
-The global part is a request definition used as a template of all other rules.
+The global section defines a request used as template for all other rules.
 When you include a header in this section, all requests regarding this rules
 will include this value.
 
@@ -207,28 +201,28 @@ will include this value.
         headers:
             Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l
 
-Just below this section we found the endpoints. We can define the rules for
-some endpoints. In the next example you can read a typical endpoint.
+Just below this section we found the endpoints. We can define rules for
+the endpoints. In the next example you can see a typical endpoint
+definition.
 
 .. code-block:: yaml
 
     endpoints:
         /{userId}/books:
 
-And if you need some rule for several endpoints you can use the * wildcard.
+If you need a single rule to affect multiple endpoints at the same time, you can use the \* *wildcard*.
 
 .. code-block:: yaml
 
     endpoints:
         /{userId}/*
 
-Inside the endpoint you can add the request definition, see avobe what items
-you can specify.
-Every thing that you add just below the endpoint will affect to every method
+Inside the endpoint you can a request definition, The items you can set
+are listed above.
+Everything you add just below the endpoint will affect every method
 inside the endpoint.
 
-You can define a path parameter, in this case we need to generate requests
-only for the user with id 500, like this:
+A path parameter can be defined. For instance, in this example we need to generate requests only for the user with id 500:
 
 .. code-block:: yaml
 
@@ -236,8 +230,8 @@ only for the user with id 500, like this:
         pathParams:
             userId: 500
 
-Then we want to change the body of the post call declared inside the
-openapi 3, so we must specify the post keyword. And you can add another
+And if we wanted to change the body of the POST call declared inside the
+OpenAPI 3, we should specify the post keyword. After which you can add another
 request definition.
 
 .. code-block:: yaml
@@ -248,25 +242,7 @@ request definition.
             type: string
                 maxLength: 40
 
-Inside the name of the example we can see another addition to Open Api
-specification, the override keyword. This keyword is false by default,
-and when it's value is true, then will ignore the complete definition
-of the Open Api file.
-
-Another addition to the Open Api specification is the dictionary type.
-This type expect to find a values keyword, and will peek one random
-element each time that generate a new value:
-
-.. code-block:: yaml
-
-    genre:
-        type: dictionary
-        values:
-            - mistery
-            - fiction
-            - suspense
-
-If we want to override all settings of the Open Api file you can override
+If we want to override all settings of the OpenAPI file you can override
 a method and not provide any new rules. This will attend only to your
 definition file.
 

--- a/docs/source/home/internals.rst
+++ b/docs/source/home/internals.rst
@@ -13,7 +13,7 @@ In \*NIX you can chain multiple commands together in a *pipeline*. Consider this
    :align: center
 
 
-In a similar fashion you can build ``API-Check`` *pipelines* chaining :samp:`commands` and :samp:`tools`. For example:
+In a similar fashion you can build ``APICheck`` *pipelines* chaining :samp:`commands` and :samp:`tools`. For example:
 
 .. image:: /_static/images/apicheck_unix_pipeline.png
    :align: center
@@ -23,7 +23,7 @@ In a similar fashion you can build ``API-Check`` *pipelines* chaining :samp:`com
 Data format
 +++++++++++
 
-To allow interoperation among :samp:`commands` and :samp:`tools` all of them share a common :samp:`JSON` data format. In other words, all of ``API-Check`` command output is :samp:`JSON` as well as the input. This allows to build pipelines (as we learnt in the previous section).
+To allow interoperation among :samp:`commands` and :samp:`tools` all of them share a common :samp:`JSON` data format. In other words, all of ``APICheck`` command output is :samp:`JSON` as well as the input. This allows to build pipelines (as we learnt in the previous section).
 
 Commands and Tools
 
@@ -35,7 +35,7 @@ Commands and Tools
 Commands & tools
 ----------------
 
-We divide ``API-Check`` components into two categories:
+We divide ``APICheck`` components into two categories:
 
 - Commands
 - Tools
@@ -97,10 +97,10 @@ The fixed value looks like the following:
 Type definition
 +++++++++++++++
 
-The type used in ``API-Check`` is a direct copy of the type definition of OpenAPI 3
+The type used in ``APICheck`` is a direct copy of the type definition of OpenAPI 3
 specification.
 Every item can be defined as an OpenAPI type. You can use custom
-types created for ``API-Check`` also. One of the allowed types is *dictionary*, that looks like:
+types created for ``APICheck`` also. One of the allowed types is *dictionary*, that looks like:
 
 .. code-block:: yaml
 

--- a/docs/source/home/overview_project.rst
+++ b/docs/source/home/overview_project.rst
@@ -1,12 +1,12 @@
 Overview
 ========
 
-What is API-Check?
+What is APICheck?
 ------------------
 
 .. _apicheck_structure:
 
-``API-Check`` is a **toolset** to help you interact with REST APIs. This means the project is a collection of tools.
+``APICheck`` is a **toolset** to help you interact with REST APIs. This means the project is a collection of tools.
 
 .. image:: /_static/images/apicheck_001_structure.png
    :align: center
@@ -15,7 +15,7 @@ What is API-Check?
 Why another REST APIs tool?
 ---------------------------
 
-``API-Check`` aims to be a universal toolset for REST APIs, allowing you to mix and match its own commands and even integrate with third party tools. This way we hope will be useful to everybody that needs to use REST APIs.
+``APICheck`` aims to be a universal toolset for REST APIs, allowing you to mix and match its own commands and even integrate with third party tools. This way we hope will be useful to everybody that needs to use REST APIs.
 
 Having in mind the tasks our user base have to achieve we classified them into three distinct categories:
 
@@ -23,12 +23,12 @@ Having in mind the tasks our user base have to achieve we classified them into t
 - :doc:`Developers </uses_cases/developers>`
 - :doc:`System Admins </uses_cases/sysadmins>`
 
-The ``API-Check`` toolset is useful for the above three user profiles.
+The ``APICheck`` toolset is useful for the above three user profiles.
 
 What exactly is the toolset made from?
 --------------------------------------
 
-``API-Check`` components are divided in two types:
+``APICheck`` components are divided in two types:
 
 - Commands: are small utilities.
 - Tools: do more complex actions.
@@ -36,4 +36,3 @@ What exactly is the toolset made from?
 .. note::
 
     You can check the complete information about :samp:`commands` and :samp:`tools` into :ref:`Core Concepts Page for more information <apicheck_structure>`
-

--- a/docs/source/home/overview_project.rst
+++ b/docs/source/home/overview_project.rst
@@ -1,45 +1,39 @@
 Overview
 ========
 
-What's API-Check
-----------------
+What is API-Check?
+------------------
 
 .. _apicheck_structure:
 
-``API-Check`` is a **toolset** to perform actions to REST APIs. This means the project is a set of grouped tools.
+``API-Check`` is a **toolset** to help you interact with REST APIs. This means the project is a collection of tools.
 
 .. image:: /_static/images/apicheck_001_structure.png
    :align: center
 
 
-Why another tool for REST APIs?
--------------------------------
+Why another REST APIs tool?
+---------------------------
 
-``API-Check`` aims to be, not only a generic toolset for REST APIs, it aims to be the tool that allow integrate with other tools.
+``API-Check`` aims to be a universal toolset for REST APIs, allowing you to mix and match its own commands and even integrate with third party tools. This way we hope will be useful to everybody that needs to use REST APIs.
 
-The idea of ``API-Check`` is to be useful for everybody that need to use REST APIs. Depending of the thinks you need to do we classified the user focused profiles in three groups:
-
-API-Check has structured with 3 user profiles in mind:
+Having in mind the tasks our user base have to achieve we classified them into three distinct categories:
 
 - :doc:`Security Engineers / Pentesters </uses_cases/pentesters>`
 - :doc:`Developers </uses_cases/developers>`
 - :doc:`System Admins </uses_cases/sysadmins>`
 
-The ``API-Check`` toolset are useful for these three profiles of users.
+The ``API-Check`` toolset is useful for the above three user profiles.
 
-What's are exactly the tool set?
---------------------------------
+What exactly is the toolset made from?
+--------------------------------------
 
-``ÀPI-Check`` has divided in two type of actions: **commands** and **tools**. In short:
+``API-Check`` components are divided in two types:
 
-- Tools: do more complex actions.
 - Commands: are small utilities.
+- Tools: do more complex actions.
 
 .. note::
 
-    You can check complete information bout :samp:`commands` and :samp:`tools` into :ref:`Core Concepts Page for more information <apicheck_structure>`
-
-
-
-
+    You can check the complete information about :samp:`commands` and :samp:`tools` into :ref:`Core Concepts Page for more information <apicheck_structure>`
 

--- a/docs/source/tools/dataset.rst
+++ b/docs/source/tools/dataset.rst
@@ -3,4 +3,4 @@ Dataset
 
 .. _dataset:
 
-Builds a dataset, analise it and create behavior graphs from user navigations stored in database.
+Builds a dataset, analyzes it and creates behavior graphs based on the user navigations stored in the database.

--- a/docs/source/tools/management.rst
+++ b/docs/source/tools/management.rst
@@ -6,17 +6,17 @@ Management tool for APICheck internals.
 API Definition
 --------------
 
-Load API Definition to database
+Load API definition to database.
 
 Manage stored APIs
 ------------------
 
-Manage stored APIs
+Manage stored APIs.
 
 Create Tool
 -----------
 
-Create structure for a new tool
+Create the scaffolding for a new tool.
 
 .. code-block:: console
 

--- a/docs/source/tools/proxy.rst
+++ b/docs/source/tools/proxy.rst
@@ -3,14 +3,15 @@ Proxy
 
 .. _proxy:
 
-Launches local proxy and stores all the navigation browsing info into a database.
+Launches a local proxy and stores all the intercepted navigation traffic into the database.
 
-Proxy tool uses `MITM Proxy <https://mitmproxy.org>`_, then be sure to follow their `installation steps <https://docs.mitmproxy.org/stable/overview-installation/>`_.
+.. note::
+        The proxy tool uses `MITM Proxy <https://mitmproxy.org>`_. Be sure to follow their `installation steps <https://docs.mitmproxy.org/stable/overview-installation/>`_.
 
 Basic usage
 -----------
 
-To basic launch of only needs to specify the database connection string. If you don't want lo launch a database server, you can use the SQLite connector.
+For the simplest proxy use case you should pass a database connection string. If you don't want lo launch a database server, you can use the SQLite connector.
 
 .. code-block:: console
 
@@ -18,5 +19,5 @@ To basic launch of only needs to specify the database connection string. If you 
 
 .. note::
 
-    The connections strings for different databases follows the SQL `Alchemy format <https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls>`_
+    The connections strings for different databases follow the SQL `Alchemy format <https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls>`_
 

--- a/docs/source/tools/send_to.rst
+++ b/docs/source/tools/send_to.rst
@@ -3,7 +3,7 @@ Send-to
 
 .. _send_to:
 
-Send API Request to given host. Optionally can send the requests through a proxy.
+Send the given HTTP API traffic. Optionally you can specify a proxy to pass through.
 
 .. image:: /_static/images/tool_send_proxy.png
 

--- a/docs/source/tools_reference.rst
+++ b/docs/source/tools_reference.rst
@@ -7,19 +7,18 @@ TNT Fuzzer
 
 - Description: OpenAPI 2.0 (Swagger) fuzzer written in python. Basically TnT for your API
 - Project url: https://github.com/Teebytes/TnT-Fuzzer
-- Has integration with ``API-Check``: **No**
+- Has integration with ``APICheck``: **No**
 
 API Fuzzer
 ++++++++++
 
 - Description: Fuzz your application using you Swagger or API Blueprint definition without coding
 - Project url: https://github.com/KissPeter/APIFuzzer
-- Has integration with ``API-Check``: **No**
+- Has integration with ``APICheck``: **No**
 
 Tavern
 ++++++
 
 - Description: A command-line tool and Python library and Pytest plugin for automated testing of RESTful APIs, with a simple, concise and flexible YAML-based syntax
 - Project url: https://github.com/taverntesting/tavern
-- Has integration with ``API-Check``: **No**
-
+- Has integration with ``APICheck``: **No**

--- a/docs/source/tools_reference.rst
+++ b/docs/source/tools_reference.rst
@@ -1,6 +1,6 @@
 This document contains third parties tools that are interesting for REST API.
 
-If you have an interesting tools and it is not listed, please `open an issue <https://github.com/BBVA/apicheck/issues>`_ and mark it as :samp:`thirdparty-tool`.
+If you know any interesting tool not listed here, please `open an issue <https://github.com/BBVA/apicheck/issues>`_ and mark it as :samp:`thirdparty-tool`.
 
 TNT Fuzzer
 ++++++++++

--- a/docs/source/uses_cases/developers.rst
+++ b/docs/source/uses_cases/developers.rst
@@ -6,33 +6,33 @@ Acceptance tests
 
 
 
-Check Flow navigation
----------------------
+Navigation Flow Checking
+------------------------
 
-Some steps, that inplies comples flows. You can use long test code cases or open a browser. navigate, save this session and re-run it for infinite times.
+Some steps imply complex navigation flows. Instead of writing long test code cases or opening a browser. Navigate through ``API-Check`` proxy, save the session and re-run it infinite times.
 
 
-Tracking API Versions
----------------------
+API Version Tracking
+--------------------
 
-One step in the C.I. pipeline, before to promote to the production environment, you can save the api defintion into an external database. 
+``API-Check`` can be used as an additional step in CI pipelines, just before promoting code to production environments, launch an API-Check instance to capture the real API definition.
 
-So you have tracked all of API versions promoted to producction.
+This way you would have all API versions promoted to production stored.
 
 
 Find low level bugs
---------------------
+-------------------
 
-Navigate using proxy. Then analyze with *dataset*. This tool able to you to discover some straing http headers, or some straing end-points called for non-sense cases.
+Navigate using ``API-Check``'s proxy. Then analyze with *dataset*. This tool allows you to discover strange http headers, or unusual endpoints used during the navigation. Also Cookie or JWT Token size growth.
 
-Cookie size increase analytics and JWT Token.
 
 API Diff
 --------
 
-Find differences between two API Versions
+Find differences between two API versions.
+
 
 Real World vs Definition
 ------------------------
 
-Find diferences between API definition and real usage of API
+Find differences between your API definition and the real API implementation.

--- a/docs/source/uses_cases/developers.rst
+++ b/docs/source/uses_cases/developers.rst
@@ -9,13 +9,13 @@ Acceptance tests
 Navigation Flow Checking
 ------------------------
 
-Some steps imply complex navigation flows. Instead of writing long test code cases or opening a browser. Navigate through ``API-Check`` proxy, save the session and re-run it infinite times.
+Some steps imply complex navigation flows. Instead of writing long test code cases or opening a browser. Navigate through ``APICheck`` proxy, save the session and re-run it infinite times.
 
 
 API Version Tracking
 --------------------
 
-``API-Check`` can be used as an additional step in CI pipelines, just before promoting code to production environments, launch an API-Check instance to capture the real API definition.
+``APICheck`` can be used as an additional step in CI pipelines, just before promoting code to production environments, launch an APICheck instance to capture the real API definition.
 
 This way you would have all API versions promoted to production stored.
 
@@ -23,7 +23,7 @@ This way you would have all API versions promoted to production stored.
 Find low level bugs
 -------------------
 
-Navigate using ``API-Check``'s proxy. Then analyze with *dataset*. This tool allows you to discover strange http headers, or unusual endpoints used during the navigation. Also Cookie or JWT Token size growth.
+Navigate using ``APICheck``'s proxy. Then analyze with *dataset*. This tool allows you to discover strange http headers, or unusual endpoints used during the navigation. Also Cookie or JWT Token size growth.
 
 
 API Diff

--- a/docs/source/uses_cases/pentesters.rst
+++ b/docs/source/uses_cases/pentesters.rst
@@ -4,67 +4,70 @@ For Pentesters
 Track API Session and export to BurpSuite / OWASP ZAP
 -----------------------------------------------------
 
-Some times is useful store the browsing navigation for an specific API. Yes, you can do that using **BurpSuite**, **OWASP ZAP** or any other similar software.
+Sometimes is useful to store the browsing navigation for an specific API. Yes, you can do this using **BurpSuite**, **OWASP ZAP** or any other similar software. But these software store the navigation using their own format, not a standardized one.
 
-But these software stores the navigation in their own format. You haven't a standard format where the navigation is stored.
+``API-Check`` proxy stores the browsing navigation in a standard relational database (MySQL, PostgresSQL, SQLite...) so you can:
 
-``API-Check`` proxy stores the browsing navigation in a standard Relational database (MySQL, PostgresSQL, SQLite...) so you can:
-
-- Find any information using standard SQL Syntax or using any DB Browser.
+- Find any information using SQL queries or using visual database browsers.
 - Re-inject the stored traffic to another tool.
 
-For this example we focus into the second case:
+For the next example we'll focus on the latter:
 
 .. image:: /_static/images/reinject_to_security_tool.png
 
 **1 - Launch the proxy**
 
-To perform that we first must launch ``API-Check`` :doc:`proxy </tools/proxy>` an record a new session:
+To perform that, we first launch ``API-Check`` :doc:`proxy </tools/proxy>` and record a new session:
 
 .. code-block:: console
 
     > at-proxy -C sqlite:///browsing_reinject.sqlite3
 
-At proxy starts, it displays the **API Version ID** that automatically are generated for that browsing. You must keep it for next step.
+When the proxy starts an automatically generated **API Version ID** for the browsing session is displayed. You must note it down for further steps.
 
-When you finish browsing, then press :samp:`CTRL+C` to stop.
+When you are finish with the browsing, press :samp:`CTRL+C` to stop the proxy.
 
-**2 - Send browsing data to security tool**
+**2 - Send browsing data to external security tools**
 
-At this point ``API-Check`` was stored in the the **browsing_reinject.sqlite3** the session. Now, with the **API Version ID** we can re-inject the data to the security tool:
+At this point the browsing session is safely stored in the file **browsing_reinject.sqlite3**. Now, with the **API Version ID** that you got earlier we can re-inject the data into the external security tool:
 
 .. code-block:: console
 
     > ac-dbcat sqlite:///browsing_reinject.sqlite3 | at-sendto --proxy 127.0.0.1:9000
 
+.. note::
+
+   Note that the security tool must behave like a proxy with the port
+   9000 open.
+
 
 Tracking API versions
 ---------------------
 
-``API-Check`` allows to track API Versions. It offers two ways to track them:
+``API-Check`` allows you to track API Versions. It offers two ways to track them:
 
-- Using Proxy: each time proxy starts creates a new unique version from domain and end-points. This version will be the same if the End-points and the server is the same.
-- Using OpenAPI 3: You can load an API definition from OpenAPI 3. ``API-Check`` tracks the version from the definition version.
+- Using the proxy: each time the proxy starts it creates a new unique version for that domain and endpoints. This version will be the same if the endpoints and the server are the same.
+- Using OpenAPI 3: You can load an OpenAPI 3. ``API-Check`` tracks the version from the definition version.
 
-Once you have the definitions, ``API-Check`` permits check API versions and history.
+Once you have API definitions loaded into ``API-Check`` you can check their versions and history.
 
 
 .. image:: /_static/images/api_versions.png
    :align: center
 
-To check the versions you can use action :samp:`apis` from :samp:`manage` tool:
+To check the versions you can use the action :samp:`apis` in the :samp:`manage` tool:
 
 .. code-block:: console
 
     > at-manage apis
 
 
-Random fuzzing using OpenAPI definition
----------------------------------------
+Endpoint fuzzing using OpenAPI definitions
+------------------------------------------
 
-``API-Check`` can generate random data to specific API end-points, using OpenAPI 3 API definition.
+``API-Check`` can generate random data for an specific API endpoint using an OpenAPI 3 API definition as a template.
 
-For this example, we toke this API definition:
+For this example, we'll take this API definition:
 
 .. _api_definition:
 
@@ -74,9 +77,9 @@ For this example, we toke this API definition:
 
 .. note::
 
-    ``API-Check`` uses **Faker** to generate data. So, it support all of types of Faker. You can check `supported types here <https://faker.readthedocs.io/en/stable/providers.html>`_
+    ``API-Check`` uses **Faker** to generate data. Therefore it supports all Faker data types. You can check the list of `supported types here <https://faker.readthedocs.io/en/stable/providers.html>`_
 
-We'll generate fuzzing values for end-point :samp:`/products/{productId}`
+We'll generate fuzzing data for the endpoint :samp:`/products/{productId}`
 
 .. code-block:: yaml
    :linenos:
@@ -118,14 +121,14 @@ We'll generate fuzzing values for end-point :samp:`/products/{productId}`
                             - 100000000
 
 
-SQL Injection attack check using API definition
------------------------------------------------
+Discovering SQL injection vulnerabilities with API definitions
+--------------------------------------------------------------
 
-As in the previous example, we can customize the data generation to perform attacks from API definition.
+As in the previous example, we can customize the data generation to perform attacks from the API definition.
 
-In this example, we'll use the the :ref:`same API definition <api_definition>` and we'll use SQL Injections from a dictionary file:
+In this example, we'll use the :ref:`same API definition <api_definition>` and use SQL Injections from a dictionary file:
 
-For the users *admin* and *root* we build the queries with injections from :samp:`sql_injections.txt` file.
+For the users *admin* and *root* we build queries that contains common injections using a dictionary file (:samp:`sql_injections.txt`).
 
 .. code-block:: yaml
    :linenos:
@@ -158,7 +161,15 @@ For the users *admin* and *root* we build the queries with injections from :samp
 User Enumeration using API definition
 -------------------------------------
 
+.. todo::
+
+    Use case description.
+
 
 Weak password check using parametrized fuzzing
 ----------------------------------------------
+
+.. todo::
+
+    Use case description.
 

--- a/docs/source/uses_cases/pentesters.rst
+++ b/docs/source/uses_cases/pentesters.rst
@@ -6,7 +6,7 @@ Track API Session and export to BurpSuite / OWASP ZAP
 
 Sometimes is useful to store the browsing navigation for an specific API. Yes, you can do this using **BurpSuite**, **OWASP ZAP** or any other similar software. But these software store the navigation using their own format, not a standardized one.
 
-``API-Check`` proxy stores the browsing navigation in a standard relational database (MySQL, PostgresSQL, SQLite...) so you can:
+``APICheck`` proxy stores the browsing navigation in a standard relational database (MySQL, PostgresSQL, SQLite...) so you can:
 
 - Find any information using SQL queries or using visual database browsers.
 - Re-inject the stored traffic to another tool.
@@ -17,7 +17,7 @@ For the next example we'll focus on the latter:
 
 **1 - Launch the proxy**
 
-To perform that, we first launch ``API-Check`` :doc:`proxy </tools/proxy>` and record a new session:
+To perform that, we first launch ``APICheck`` :doc:`proxy </tools/proxy>` and record a new session:
 
 .. code-block:: console
 
@@ -44,12 +44,12 @@ At this point the browsing session is safely stored in the file **browsing_reinj
 Tracking API versions
 ---------------------
 
-``API-Check`` allows you to track API Versions. It offers two ways to track them:
+``APICheck`` allows you to track API Versions. It offers two ways to track them:
 
 - Using the proxy: each time the proxy starts it creates a new unique version for that domain and endpoints. This version will be the same if the endpoints and the server are the same.
-- Using OpenAPI 3: You can load an OpenAPI 3. ``API-Check`` tracks the version from the definition version.
+- Using OpenAPI 3: You can load an OpenAPI 3. ``APICheck`` tracks the version from the definition version.
 
-Once you have API definitions loaded into ``API-Check`` you can check their versions and history.
+Once you have API definitions loaded into ``APICheck`` you can check their versions and history.
 
 
 .. image:: /_static/images/api_versions.png
@@ -65,7 +65,7 @@ To check the versions you can use the action :samp:`apis` in the :samp:`manage` 
 Endpoint fuzzing using OpenAPI definitions
 ------------------------------------------
 
-``API-Check`` can generate random data for an specific API endpoint using an OpenAPI 3 API definition as a template.
+``APICheck`` can generate random data for an specific API endpoint using an OpenAPI 3 API definition as a template.
 
 For this example, we'll take this API definition:
 
@@ -77,7 +77,7 @@ For this example, we'll take this API definition:
 
 .. note::
 
-    ``API-Check`` uses **Faker** to generate data. Therefore it supports all Faker data types. You can check the list of `supported types here <https://faker.readthedocs.io/en/stable/providers.html>`_
+    ``APICheck`` uses **Faker** to generate data. Therefore it supports all Faker data types. You can check the list of `supported types here <https://faker.readthedocs.io/en/stable/providers.html>`_
 
 We'll generate fuzzing data for the endpoint :samp:`/products/{productId}`
 
@@ -172,4 +172,3 @@ Weak password check using parametrized fuzzing
 .. todo::
 
     Use case description.
-

--- a/docs/source/uses_cases/sysadmins.rst
+++ b/docs/source/uses_cases/sysadmins.rst
@@ -1,12 +1,14 @@
 SysAdmins
 =========
 
-Find strange servers in API
----------------------------
 
-With command "dataset" try to find anomalies in headers
+Find unexpected servers serving your API
+----------------------------------------
+
+With the *dataset* command try to find anomalies in headers.
+
 
 Check remote servers for different APIs
 ---------------------------------------
 
-Load API from database. The make a query and extract if the have servers configured
+With the API loaded in the database. Use a query to check that all your configured server are in use.

--- a/docs/source/uses_cases/uses_cases_overview.rst
+++ b/docs/source/uses_cases/uses_cases_overview.rst
@@ -1,14 +1,7 @@
 Overview
 ========
 
-cases
------
+.. todo::
 
-asdf
-
-
-
-
-
-
+   Write some nice use cases.
 


### PR DESCRIPTION
This pull request fix some documentation typos and errors. But there are some things pending:

- Standardize all `API-Check` mentions to \`\`APICheck\`\`.
- Remove `API-Test` mentions.
- Revisit all examples and correct the proper tool/command names because a lot of them are wrong.

They can be addressed in the future.