### PR TITLE
Fix URL for RFC 7807

### DIFF
--- a/tools-edge/oas-checker/spectral.yml
+++ b/tools-edge/oas-checker/spectral.yml
@@ -225,9 +225,9 @@ rules:
       function: falsy
   use-problem-json-for-errors:
     description: "Error responses should support [RFC
-      7807](https://tools.ietf.org/html/rfc6648) "
+      7807](https://tools.ietf.org/html/rfc7807) "
     message: Error responses should support [RFC
-      7807](https://tools.ietf.org/html/rfc6648) in {{path}}.
+      7807](https://tools.ietf.org/html/rfc7807) in {{path}}.
     formats:
       - oas3
     severity: error


### PR DESCRIPTION
The URL referencing RFC 7807 is pointing to RFC 6648.

This fix issue #33 