### PR TITLE
Update security rules. Lock spectral version.

### DIFF
--- a/tools-edge/oas-checker/Dockerfile
+++ b/tools-edge/oas-checker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14.11.0-alpine3.12
 
 RUN apk update && \
     apk upgrade && \
-    npm install -g @stoplight/spectral
+    npm install -g @stoplight/spectral@^5.7.2
 
 # Load default ruleset from a suitable source
 COPY spectral.yml .spectral.yml

--- a/tools-edge/oas-checker/spectral.yml
+++ b/tools-edge/oas-checker/spectral.yml
@@ -1,6 +1,6 @@
 #
 # See technical recommendations on Italian Guidelines
-#
+#  in https://github.com/italia/api-oas-checker for discussing rules.
 #
 #
 extends: spectral:oas

--- a/tools-edge/oas-checker/spectral.yml
+++ b/tools-edge/oas-checker/spectral.yml
@@ -4,10 +4,15 @@
 #
 #
 extends: spectral:oas
-
+# Skipping has-x-summary: off
+# Skipping has-x-api-id: off
+# Skipping number-format: off
+# Skipping integer-format: off
+# Skipping allowed-integer-format: off
+# Skipping allowed-number-format: off
 rules:
   paths-kebab-case:
-    description: >
+    description: |
       Paths should be kebab-case.
     message: "{{property}} is not kebab-case: {{error}}"
     severity: warn
@@ -45,6 +50,17 @@ rules:
         type: pascal
         separator:
           char: "-"
+  no-forbidden-headers:
+    description: OAS do not allow using Authorization, Content-Type and Accept in the spec.
+    message: "{{error}} in {{path}} {{value}}"
+    severity: error
+    given:
+      - $..parameters[?(@.in == 'header')].name
+      - $.[responses][*].headers.*~
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: /^(accept|content-type|authorization)$/i
   no-x-headers-request:
     description: All 'HTTP' headers SHOULD NOT include 'X-' headers
       (https://tools.ietf.org/html/rfc6648).
@@ -92,19 +108,9 @@ rules:
       function: pattern
       functionOptions:
         match: ^https://.*
-  has-x-summary:
-    description: API must have an one-liner summary field in x-summary {{path}}
-    given: $
-    severity: error
-    recommended: true
-    type: style
-    formats:
-      - oas3
-    then:
-      field: info.x-summary
-      function: truthy
   has-termsOfService:
-    description: API MUST reference the URL of the Terms of Service {{path}}
+    description: "API MUST reference the URL of the Terms of Service in
+      #/info/termsOfService"
     given: $
     severity: error
     recommended: true
@@ -115,7 +121,7 @@ rules:
       field: info.termsOfService
       function: truthy
   has-contact:
-    description: "API MUST reference a contact, either url or email: {{path}}"
+    description: "API MUST reference a contact, either url or email in #/info/contact"
     given: $
     severity: error
     recommended: true
@@ -125,78 +131,17 @@ rules:
     then:
       field: info.contact
       function: truthy
-  has-x-api-id:
-    description: API must have an unique identifier in x-api-id {{path}}
-    given: $
+  use-semver:
     severity: error
     recommended: true
-    type: style
+    message: |-
+      Specs should follow semantic versioning. {{value}} is not a valid version.
+      See https://semver.org/#semantic-versioning-specification-semver
+    given: $.info.version
     then:
-      field: info.x-api-id
-      function: truthy
-  number-format:
-    description: Number must specify a format.
-    message: Schema of type number must specify a format. {{path}}
-
-    formats:
-      - oas3
-    severity: error
-    recommended: true
-    given: |
-      $.[?(@.type=="number")]
-    then:
-      field: format
-      function: truthy
-  integer-format:
-    description: Integer must specify a format.
-    message: Schema of type integer must specify a format. {{path}}
-
-    formats:
-      - oas3
-    severity: error
-    recommended: true
-    given: |
-      $.[?(@.type=="integer")]
-    then:
-      field: format
-      function: truthy
-  allowed-integer-format:
-    description: Integer format should be in the table.
-    message: integer format is "{{value}}", expected one of [int32, int64]. {{path}}
-    formats:
-      - oas3
-    severity: hint
-    recommended: true
-    given: |
-      $.[?(@.type=="integer")]
-    then:
-      field: format
-      function: enumeration
+      function: pattern
       functionOptions:
-        values:
-          - int32
-          - int64
-  allowed-number-format:
-    description: Integer format should be in the table.
-    message: number format is "{{value}}", expected one of [decimal32, decimal64,
-      decimal128, float, double]. {{path}}
-
-    formats:
-      - oas3
-    severity: hint
-    recommended: true
-    given: |
-      $.[?(@.type=="number")]
-    then:
-      field: format
-      function: enumeration
-      functionOptions:
-        values:
-          - decimal32
-          - decimal64
-          - float
-          - double
-          - decimal128
+        match: ^[0-9]+.[0-9]+.[0-9]+(-[a-z0-9+.-]+)?
   oas2: false
   no-swagger-2:
     description: Swagger 2 files are not allowed. Use OpenAPI >= 3.0
@@ -210,11 +155,9 @@ rules:
       field: swagger
       function: falsy
   patch-media-type:
-    description: >-
-      application/json is not an appropriate media-type for PATCH.
-
-
+    description: application/json is not an appropriate media-type for PATCH.
     message: application/json is not an appropriate media-type for PATCH. {{path}}
+      See https://www.rfc-editor.org/errata/eid3169
     formats:
       - oas3
     severity: error
@@ -239,8 +182,11 @@ rules:
           - application/problem+xml
           - application/problem+json
   use-problem-schema:
-    description: "WARN: This rule is under implementation. Your problem schema
-      doesn't seem to match RFC7807. Are you sure it is ok?  "
+    description: >-
+      WARN: This rule is under implementation.
+
+      Your problem schema doesn't seem to match RFC7807. Are you sure it is ok?
+
     message: Your schema doesn't seem to match RFC7807. Are you sure it is ok? {{path}}
     formats:
       - oas3
@@ -260,9 +206,8 @@ rules:
             detail:
               type: string
   hint-problem-schema:
-    description: Your problem schema doesn't seem to match RFC7807. Are you sure
-      it is ok?
-
+    description: Your problem schema doesn't seem to match RFC7807. Are you sure it
+      is ok?
     message: Error response doesn't seem to match RFC7807. Are you sure it is ok?
       {{path}}
     formats:
@@ -277,7 +222,7 @@ rules:
         notMatch: message|code|msg
   missing-retry-after:
     description: APIs should use Retry-After on 429 and 503 responses.
-    message: "Missing ratelimit header: {{property}} in {{path}} "
+    message: "Missing ratelimit header: {{property}} in {{path}}"
     formats:
       - oas3
     severity: warn
@@ -289,7 +234,6 @@ rules:
   missing-ratelimit:
     description: APIs should use ratelimit headers at least on successful responses.
     message: Missing ratelimit headers. {{property}} {{error}} {{path}}
-
     formats:
       - oas3
     severity: warn
@@ -311,6 +255,9 @@ rules:
             - X-RateLimit-Reset
             - RateLimit-Reset
         function: xor
+#
+# Extra security rule
+#
   response-with-json-object:
     message: JSON responses must use json objects (eg "{}"), not {{value}}. {{path}}
     severity: warn
@@ -321,4 +268,67 @@ rules:
       function: pattern
       functionOptions:
         match: object
+
+  array-boundaries:
+    description: Arrays should be limited.
+    message: Schema of type array must specify maxItems and minItems. {{path}} {{error}}
+    formats:
+      - oas3
+    severity: warn
+    recommended: true
+    given:
+      - $.[?(@.type=="array")]
+    then:
+      - field: maxItems
+        function: defined
+      - field: minItems
+        function: defined
+  number-boundaries:
+    description: Schema of type number or integer must specify a maximum and a minimum.
+    message: Schema of type number or integer must specify a maximum and a minimum.
+      {{path}} {{error}}
+    formats:
+      - oas3
+    severity: warn
+    recommended: true
+    given:
+      - $.[?(@.type=="number")]
+      - $.[?(@.type=="integer")]
+    then:
+      - field: maximum
+        function: defined
+      - field: minimum
+        function: defined
+  string-maxlength:
+    description: String length should be limited.
+    message: Strings (non enum) must specify a maximum length. {{path}} {{error}}
+    formats:
+      - oas3
+    severity: warn
+    recommended: true
+    given:
+      - $.[?(@.type=="string" && !@.enum )]
+    then:
+      - field: maxLength
+        function: defined
+  string-pattern-or-format-or-enum:
+    description: String values should be constrained.
+    message: Strings (non enum) must specify a pattern or a format. {{path}}
+    formats:
+      - oas3
+    severity: hint
+    recommended: true
+    given:
+      - $.[[?( @.type == "string" && !@.enum )]]
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          anyOf:
+            - required:
+                - pattern
+            - required:
+                - format
+          additionalProperties: true
 


### PR DESCRIPTION
## This PR

- use latest spectral version ^5.7.2
- improve security rules, including:
  * constraints strings, numbers and arrays with min/max instead of format (we can discuss on that) @cr0hn 
  * removes compulsory `/status` path
  * signals usage of oas-forbidden headers
